### PR TITLE
Add betterindex and comment unsafe code

### DIFF
--- a/matrix.hpp
+++ b/matrix.hpp
@@ -73,8 +73,7 @@ public:
     Matrix2D<T> operator*(const Matrix2D<T>&) const;
     Matrix2D<T> operator/(const Matrix2D<T>&) const;
     T* operator[](unsigned i) const;
-    T** operator()() const;
-    operator const T**() const;
+    T operator()(unsigned i, unsigned j) const;
     virtual ~Matrix2D() = default;
     static Matrix2D<T> I(unsigned short I);
     void display() const;

--- a/matrix.tcc
+++ b/matrix.tcc
@@ -288,8 +288,8 @@ T* Matrix2D<T>::operator[](unsigned i) const{
 
 //! UNSAFE!! Use with caution!
 template <typename T>
-T** Matrix2D<T>::operator()() const{
-    return data.get();
+T Matrix2D<T>::operator()(unsigned i, unsigned j) const{
+    return get(i, j);
 }
 
 // Returns an NxN identity matrix of type T
@@ -353,13 +353,13 @@ void Matrix2D<T>::row_operation(unsigned i, unary_operator_fn<T> fn){
 }
 
 //! Incomplete behaviour
-template <typename T>
-void Matrix2D<T>::row_operation(unsigned i, unsigned j, binary_operator_fn<T> fn){
-    if(i >= M || j >= N) throw std::out_of_range("row_operation::row index out of range");
-    for(unsigned k = 0; j < N; j++){
-        set(i, j, fn(get(i, k), get(j, k)));
-    }
-}
+// template <typename T>
+// void Matrix2D<T>::row_operation(unsigned i, unsigned j, binary_operator_fn<T> fn){
+//     if(i >= M || j >= N) throw std::out_of_range("row_operation::row index out of range");
+//     for(unsigned k = 0; j < N; j++){
+//         set(i, j, fn(get(i, k), get(j, k)));
+//     }
+// }
 
 
 template <typename T>


### PR DESCRIPTION
Matrix2D is a function object that returns get(i,j) when called this means **A(i,j)** and  A.get(i,j) are thesame
The binary row operation is ambigous and has been commented out